### PR TITLE
Tag v0.13 to publish all original changes of the CVS repo in this release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2025-09-13 Florian Fuchs <fuchsfl@gmail.com>
+	increment version number 0.12 -> 0.13
+
 2005-06-09  Hiroshi DOYU  <Hiroshi_DOYU@montavista.co.jp>
 
 	Alain Volmat <avolmat@src.ricoh.co.jp>

--- a/main.c
+++ b/main.c
@@ -51,7 +51,7 @@ int stub_stack[stub_stack_size]
 int *stub_sp;
 
 static const char *const banner = "\n"
-    "SH IPL+g version 0.12, Copyright (C) 2001 Free Software Foundation, Inc.\n"
+    "SH IPL+g version 0.13, Copyright (C) 2001 Free Software Foundation, Inc.\n"
     "\n"
     "This software comes with ABSOLUTELY NO WARRANTY; for details type `w'.\n"
     "This is free software, and you are welcome to redistribute it under\n"


### PR DESCRIPTION
This release contains all modifications after the 0.12 commit message of the original CVS repository.